### PR TITLE
Fix protobuf version.

### DIFF
--- a/container-engine/requirements.txt
+++ b/container-engine/requirements.txt
@@ -1,4 +1,5 @@
 Flask==0.11.1
+protobuf==3.0.0
 gcloud==0.18.1
 gunicorn==19.6.0
 six==1.10.0


### PR DESCRIPTION
Saw this when going through codelabs https://codelabs.developers.google.com/codelabs/cp100-container-engine/#3 after first attempt in deploying to k8s cluster:

```
ImportError: libprotobuf.so.12: cannot open shared object file: No such file or directory
```

This change forces protobuf v3.0.0 instead of pulling in latest version.