### PR TITLE
Missing dependency

### DIFF
--- a/container-engine/requirements.txt
+++ b/container-engine/requirements.txt
@@ -3,3 +3,4 @@ gcloud==0.18.1
 gunicorn==19.6.0
 six==1.10.0
 honcho==0.7.1
+protobuf=3.0.0


### PR DESCRIPTION
When starting the docker container I was getting this error:
 File "/env/local/lib/python2.7/site-packages/google/protobuf/descriptor.py", line 46, in <module>
2017-01-17T11:09:22.892059882Z 11:09:22 bookshelf.1 |     from google.protobuf.pyext import _message

Adding this dependency fix it