### PR TITLE
Specific version of protobuf dependency

### DIFF
--- a/compute-engine/requirements.txt
+++ b/compute-engine/requirements.txt
@@ -1,4 +1,5 @@
 Flask==0.11.1
+protobuf==3.0.0
 gcloud==0.18.1
 gunicorn==19.6.0
 six==1.10.0


### PR DESCRIPTION
Similar to #1. 

Same fix that was done for the `container-engine` but for `compute-engine`