### PR TITLE
Update requirements.txt

### DIFF
--- a/container-engine/requirements.txt
+++ b/container-engine/requirements.txt
@@ -1,5 +1,5 @@
 Flask==0.11.1
-protobuf==3.0.0
+protobuf==3.6.0
 gcloud==0.18.1
 gunicorn==19.6.0
 six==1.10.0


### PR DESCRIPTION
Lab will not work on current run-time with the old version of gRPC